### PR TITLE
Fix infinite loop caused by unexpected escape sequence

### DIFF
--- a/token.go
+++ b/token.go
@@ -206,6 +206,8 @@ func (t *Token) ValueUnescaped() []byte {
 					result = append(result, str[:idx]...)
 					result = append(result, p...)
 					str = str[idx+len(p)+1:]
+				} else {
+					break
 				}
 			} else {
 				break

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -86,6 +86,7 @@ func TestTokenize(t *testing.T) {
 			{"два три", Token{key: TokenString, string: quote, value: []byte("\"два три\"")}},
 			{"one\" two", Token{key: TokenString, string: quote, value: []byte(`"one\" two"`)}},
 			{"", Token{key: TokenString, string: quote, value: []byte("\"\"")}},
+			{`one\' two`, Token{key: TokenString, string: quote, value: []byte(`"one\' two"`)}},
 		}
 		for _, v := range framed {
 			stream := tokenizer.ParseBytes(v.token.value)


### PR DESCRIPTION
Hi, this code triggers endless loop in the `ValueUnescapedString()` function:

```
tokenizer := New()
tokenizer.DefineStringToken(TokenDoubleQuoted, `"`, `"`).
	SetEscapeSymbol(BackSlash)

stream := tokenizer.ParseString(`"one\' two"`)
fmt.Println(stream.CurrentToken().ValueUnescapedString())
```

I expect this code to output the following string:

```
one\' two
```

This PR fixes the issue.