### PR TITLE
Implement negatively signed numbers

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -122,11 +122,11 @@ func (parser *jsonParser) error(stream *Stream) error {
 func TestJsonParser(t *testing.T) {
 	parser := newJSONParser()
 
-	data, err := parser.Parse([]byte(`{"one": 1, "two": "three", "four": [5, "six", 7.8, {}]}`))
+	data, err := parser.Parse([]byte(`{"one": 1, "two": "three", "four": [5, "six", 7.8, -9, -99.9, {}]}`))
 	require.NoError(t, err)
 	require.Equal(t, map[string]interface{}{
 		"one":  int64(1),
 		"two":  "three",
-		"four": []interface{}{int64(5), "six", 7.8, map[string]interface{}{}},
+		"four": []interface{}{int64(5), "six", 7.8, int64(-9), -99.9, map[string]interface{}{}},
 	}, data)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -122,11 +122,13 @@ func (parser *jsonParser) error(stream *Stream) error {
 func TestJsonParser(t *testing.T) {
 	parser := newJSONParser()
 
-	data, err := parser.Parse([]byte(`{"one": 1, "two": "three", "four": [5, "six", 7.8, -9, -99.9, {}]}`))
+	data, err := parser.Parse([]byte(`{"one": 1, "two": "three", "four": [5, "six", 7.8, -9, -99.9, {}], "five-5": "5-five", "6-six": "six-6"}`))
 	require.NoError(t, err)
 	require.Equal(t, map[string]interface{}{
 		"one":  int64(1),
 		"two":  "three",
 		"four": []interface{}{int64(5), "six", 7.8, int64(-9), -99.9, map[string]interface{}{}},
+		"five-5": "5-five",
+		"6-six": "six-6",
 	}, data)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kettek/tokenizer
+module github.com/bzick/tokenizer
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bzick/tokenizer
+module github.com/kettek/tokenizer
 
 go 1.13
 

--- a/parser.go
+++ b/parser.go
@@ -319,6 +319,8 @@ func (p *parsing) parseNumber() bool {
 				if isNumberByte(nextByte) {
 					if start == -1 {
 						start = p.pos
+					} else {
+						break
 					}
 				} else {
 					break

--- a/parser.go
+++ b/parser.go
@@ -315,6 +315,14 @@ func (p *parsing) parseNumber() bool {
 				} else {
 					break
 				}
+			} else if !hasExp && p.curr == '-' { // Allow starting numbers from a negative sign.
+				if isNumberByte(nextByte) {
+					if start == -1 {
+						start = p.pos
+					}
+				} else {
+					break
+				}
 			} else {
 				break
 			}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -46,6 +46,7 @@ func TestTokenize(t *testing.T) {
 	t.Run("integers", func(t *testing.T) {
 		integers := []item{
 			{int64(1), Token{key: TokenInteger, value: []byte("1")}},
+			{int64(-1), Token{key: TokenInteger, value: []byte("-1")}},
 			{int64(123456), Token{key: TokenInteger, value: []byte("123456")}},
 			{int64(123456), Token{key: TokenInteger, value: []byte("123_456")}},
 		}
@@ -63,10 +64,12 @@ func TestTokenize(t *testing.T) {
 			{2.3, Token{key: TokenFloat, value: []byte("2.3")}},
 			{2.0, Token{key: TokenFloat, value: []byte("2.")}},
 			{0.2, Token{key: TokenFloat, value: []byte(".2")}},
+			{-2.3, Token{key: TokenFloat, value: []byte("-2.3")}},
 			{2.3e4, Token{key: TokenFloat, value: []byte("2.3e4")}},
 			{2.3e-4, Token{key: TokenFloat, value: []byte("2.3e-4")}},
 			{2.3e+4, Token{key: TokenFloat, value: []byte("2.3E+4")}},
 			{2e4, Token{key: TokenFloat, value: []byte("2e4")}},
+			{-1e1, Token{key: TokenFloat, value: []byte("-1e1")}},
 		}
 		for _, v := range floats {
 			t.Run(string(v.token.value), func(t *testing.T) {


### PR DESCRIPTION
With the current implementation, having negative numbers, such as "-9" or "-9.99" will not be parsed as numbers but rather as keywords. This adjustments properly sets the start of number parsing to include the sign.